### PR TITLE
[Testing] Update travis config for drupal 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   - composer require drupal/encryption:1.x-dev
   - composer require drupal/contact_block:1.x-dev
   - composer require drupal/contact_storage:1.x-dev
-  - php -r 'if ($c = json_decode(file_get_contents("composer.json"))) {$c->repositories[] = ["type"=>"vcs", "url"=>"https://github.com/jaesin/marketo-rest-api"];file_put_contents("composer.json", json_encode($c, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES).chr(10));}'
+  - php -r 'if ($c = json_decode(file_get_contents("composer.json"))) {$c->repositories = [(object) ["type"=>"vcs", "url"=>"https://github.com/jaesin/marketo-rest-api"]];file_put_contents("composer.json", json_encode($c, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES).chr(10));}'
   - composer require dchesterton/marketo-rest-api:dev-master
 
   # Reference module in build site.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,52 +1,67 @@
 language: php
+sudo: false
 
 php:
   - 5.5
   - 5.6
+  - 7
+  - hhvm
 
 env:
   global:
-    - DATABASE='drupal'
-    - DB_USERNAME='root'
-    - DB_ENCODE='utf8'
-    - DOCROOT='/var/www'
+    - marketo_ma_munchkin_account_id=''
+    - marketo_ma_rest_client_id=''
+    - marketo_ma_rest_client_secret=''
+    - marketo_ma_munchkin_api_private_key=''
+  matrix:
+    - DRUPAL_VERSION="~8.1.0"
+
+matrix:
+  allow_failures:
+    # We cannot use hhvm-nightly since that does not work in Travis CI's old
+    # Ubuntu 12.04.
+    - php: hhvm
+
+  # Don't wait for the allowed failures to build.
+  fast_finish: true
 
 mysql:
-  database: $DATABASE
-  username: $DB_USERNAME
-  encoding: $DB_ENCODE
-
-before_install:
-  - sudo apt-get update > /dev/null
-  - composer self-update
-  - pear channel-discover pear.drush.org
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  database: drupal
+  username: root
+  encoding: utf8
 
 install:
-  - sudo apt-get install -y --force-yes apache2 libapache2-mod-php5 php5-curl php5-mysql php5-intl
-  - sudo a2enmod rewrite
-  - sudo cp -f tests/travis-ci-apache /etc/apache2/sites-available/default
-  - sudo service apache2 restart
-  - pear install drush/drush
-  - phpenv rehash
-  - cd $TRAVIS_BUILD_DIR
-  - export MODULE=$(basename $(pwd))
-  - export MODULE_DIR=$DOCROOT/sites/all/modules/$MODULE
-  - sudo chmod -R 777 /var
-  - drush dl drupal --destination=/var --drupal-project-rename=www --yes
-  - drush si --db-url="mysql://$DB_USERNAME@127.0.0.1/$DATABASE" -r $DOCROOT --yes
-  - ln -s $TRAVIS_BUILD_DIR $MODULE_DIR
-  - cd $TRAVIS_BUILD_DIR/..
-  - wget http://selenium-release.storage.googleapis.com/2.47/selenium-server-standalone-2.47.1.jar
-  - java -jar selenium-server-standalone-2.47.1.jar > /dev/null 2>&1 &
+  # Remove Xdebug.
+  - phpenv config-rm xdebug.ini || true
+  # Create database.
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS drupal CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci'
+  # Export database variable for kernel tests.
+  - export SIMPLETEST_DB=mysql://root:@127.0.0.1/drupal
+  # Export web server URL for browser tests.
+  - export SIMPLETEST_BASE_URL=http://localhost:8888
+
+  # Remember the module folder.
+  - TESTDIR=$(pwd)
+  # Navigate out of module directory to prevent blown stack by recursive module lookup.
+  - cd ..
+
+  # Install drupal and dependent modules with composer.
+  - composer create-project drupal/drupal drupal "$DRUPAL_VERSION" --no-interaction && cd drupal
+  - composer config repositories.drupal composer https://packages.drupal.org/8
+  - composer require drupal/encryption:1.x-dev
+  - composer require drupal/contact_block:1.x-dev
+  - composer require drupal/contact_storage:1.x-dev
+  - php -r 'if ($c = json_decode(file_get_contents("composer.json"))) {$c->repositories[] = ["type"=>"vcs", "url"=>"https://github.com/jaesin/marketo-rest-api"];file_put_contents("composer.json", json_encode($c, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES).chr(10));}'
+  - composer require dchesterton/marketo-rest-api:dev-master
+
+  # Reference module in build site.
+  - ln -s $TESTDIR modules/marketo_ma
 
 before_script:
-  - cd $MODULE_DIR/tests
-  - cp behat.yml.dist behat.yml
-  - composer install
-  - vendor/bin/behat features/travis-ci.feature
+  # Start a web server on port 8888, run in the background; wait for
+  # initialization.
+  - nohup php -S localhost:8888 > /dev/null 2>&1 &
 
 script:
-  - cd $MODULE_DIR/tests
-  - vendor/bin/behat --tags="~travis&&~live"
+  # Run the PHPUnit tests which also include the kernel tests.
+  - ./vendor/phpunit/phpunit/phpunit -c ./core/phpunit.xml.dist --verbose ./modules/marketo_ma

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - marketo_ma_munchkin_api_private_key='qux'
   matrix:
     - DRUPAL_VERSION="~8.1.0"
+    - DRUPAL_VERSION="~8.2.0"
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ php:
 
 env:
   global:
-    - marketo_ma_munchkin_account_id=''
-    - marketo_ma_rest_client_id=''
-    - marketo_ma_rest_client_secret=''
-    - marketo_ma_munchkin_api_private_key=''
+    - marketo_ma_munchkin_account_id='foo'
+    - marketo_ma_rest_client_id='bar'
+    - marketo_ma_rest_client_secret='baz'
+    - marketo_ma_munchkin_api_private_key='qux'
   matrix:
     - DRUPAL_VERSION="~8.1.0"
 
@@ -51,7 +51,7 @@ install:
   - composer require drupal/encryption:1.x-dev
   - composer require drupal/contact_block:1.x-dev
   - composer require drupal/contact_storage:1.x-dev
-  - php -r 'if ($c = json_decode(file_get_contents("composer.json"))) {$c->repositories = [(object) ["type"=>"vcs", "url"=>"https://github.com/jaesin/marketo-rest-api"]];file_put_contents("composer.json", json_encode($c, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES).chr(10));}'
+  - cat composer.json | jq '.repositories |= [{"type": "vcs", "url": "https://github.com/jaesin/marketo-rest-api"}]' | tee composer.json
   - composer require dchesterton/marketo-rest-api:dev-master
 
   # Reference module in build site.

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ before_script:
   # Start a web server on port 8888, run in the background; wait for
   # initialization.
   - nohup php -S localhost:8888 > /dev/null 2>&1 &
+  # Start PhantomJS.
+  - phantomjs --ssl-protocol=any --ignore-ssl-errors=true ./vendor/jcalderonzumba/gastonjs/src/Client/main.js 8510 1024 768 > /dev/null 2>&1 &
 
 script:
   # Run the PHPUnit tests which also include the kernel tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   - composer require drupal/encryption:1.x-dev
   - composer require drupal/contact_block:1.x-dev
   - composer require drupal/contact_storage:1.x-dev
-  - cat composer.json | jq '.repositories |= [{"type": "vcs", "url": "https://github.com/jaesin/marketo-rest-api"}]' | tee composer.json
+  - "cat composer.json | jq '.repositories |= [{\"type\": \"vcs\", \"url\": \"https://github.com/jaesin/marketo-rest-api\"}]' | tee composer.json"
   - composer require dchesterton/marketo-rest-api:dev-master
 
   # Reference module in build site.


### PR DESCRIPTION
This is the start of getting travis set up for D8. There are API integration tests so those will fail without proper credentials. 

Credentials can be add by setting: 

```
env:
  global:
    - marketo_ma_munchkin_account_id='foo'
    - marketo_ma_rest_client_id='bar'
    - marketo_ma_rest_client_secret='baz'
    - marketo_ma_munchkin_api_private_key='qux'

```

You wouldn't actually want to do this but you could use secure environment variable with: 

```
env:
  global:
    - secure: mcUCykGm4bUZ3CaW6AxrI...
```

It might be better to remove actual API integration in the testing and use mock responses. I guess we can make the assumption that the API client library has API integration tests (which it does).

That said, I think that making the tests pass is a different issue. This is just to get the tests running in the first place.
