### PR TITLE
Issue #2813537 by Jaesin: Uncaught PHP Exception Exception from clien…

### DIFF
--- a/marketo_ma.services.yml
+++ b/marketo_ma.services.yml
@@ -8,8 +8,12 @@ services:
   #   example the field mapping along the way.
   marketo_ma.api_client:
     class: Drupal\marketo_ma\Service\MarketoMaApiClient
-    arguments: ['@config.factory']
+    arguments: ['@config.factory', '@logger.channel.marketo_ma']
   # The Marketo MA munchkin service
   marketo_ma.munchkin:
     class: Drupal\marketo_ma\Service\MarketoMaMunchkin
     arguments: ['@config.factory', '@current_user', '@current_route_match']
+  # The Marketo MA logger.
+  logger.channel.marketo_ma:
+    parent: logger.channel_base
+    arguments: ['marketo_ma']


### PR DESCRIPTION
I've seen this error a couple of times.

```
Uncaught PHP Exception Exception: "Must provide either a URL or Munchkin code." at .../docroot/vendor/dchesterton/marketo-rest-api/src/Client.php line 49
```

We need to validate the configuration before trying to instantiate the client library.
