### PR TITLE
[WIP] Change Webform mapping to marketo field id.

### DIFF
--- a/includes/marketo_ma.data.inc
+++ b/includes/marketo_ma.data.inc
@@ -1,0 +1,236 @@
+<?php
+
+/**
+ * @file
+ * Class and methods for interacting with the Marketo Data object.
+ */
+
+/**
+ * Marketo Data Interface
+ */
+interface MarketoData {
+  /**
+   * Get raw data array.
+   * @return mixed
+   */
+  public function getRawData();
+
+  /**
+   * Set data array.
+   *
+   * @param array $data
+   */
+  public function setData(array $data);
+
+  /**
+   * Get data array formatted per tracking method.
+   * @return mixed
+   */
+  public function getFormattedData();
+
+  /**
+   * Set formatted data array.
+   * @param $formatted_data
+   */
+  public function setFormattedData($formatted_data);
+
+  /**
+   * Get the email address.
+   *
+   * @return mixed
+   */
+  public function getEmailAddress();
+
+  /**
+   * Set the email address.
+   *
+   * @return mixed
+   */
+  public function setEmailAddress($email);
+
+  /**
+   * Get the email key.
+   * @param null $tracking_method
+   * @return mixed
+   */
+  public static function getEmailKey($tracking_method = null);
+}
+
+/**
+ * Marketo MA Data
+ */
+class MarketoMaData implements MarketoData {
+  // Marketo id|value data array.
+  private $data;
+  // Current tracking method.
+  private $tracking_method;
+  // Formatted data.
+  private $formatted_data;
+
+  /**
+   * MarketoMaData constructor.
+   *
+   * @param array $data
+   * @param string $tracking_method
+   */
+  public function __construct(array $data, $tracking_method = 'munchkin') {
+    $this->setData($data);
+    $this->setTrackingMethod($tracking_method);
+    $this->getFormattedData();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setData(array $data) {
+    $this->data = $data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormattedData() {
+    if (!$this->formatted_data) {
+      $this->setFormattedData($this->formatData());
+    }
+    return $this->formatted_data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRawData() {
+    return $this->data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTrackingMethod() {
+    return $this->tracking_method;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  private function setTrackingMethod($tracking_method) {
+    $this->tracking_method = $tracking_method;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEmailAddress() {
+    $email = NULL;
+    $formatted_data = $this->getFormattedData();
+    // Format the data based on tracking method.
+    switch ($this->getTrackingMethod()) {
+      case 'rest':
+        if (!empty($formatted_data['email'])) {
+          $email = $formatted_data['email'];
+        }
+        break;
+      case 'munchkin':
+      default:
+        if (!empty($formatted_data['Email'])) {
+          $email = $formatted_data['Email'];
+        }
+        break;
+    }
+    return $email;
+  }
+
+  /**
+   * Format the data based on tracking method.
+   *
+   * @return array
+   */
+  public function formatData() {
+    $raw_data = $this->getRawData();
+    $formatted_data = array();
+    // Format the data based on tracking method.
+    switch ($this->getTrackingMethod()) {
+      case 'rest':
+        // Replace marketo_id with value of MARKETO_REST_LEAD_FIELD_REST_KEY.
+        foreach ($raw_data as $id => $value) {
+          // Get the row corresponding to the marketo id.
+          $result = db_select(MARKETO_MA_SCHEMA_LEAD_FIELDS)
+            ->fields(MARKETO_MA_SCHEMA_LEAD_FIELDS)
+            ->condition(MARKETO_MA_LEAD_FIELD_ID, $id)
+            ->execute()
+            ->fetchAll();
+          // Cycle through the result row(s) and set the new rest field key.
+          foreach ($result as $field) {
+            if (isset($field->{MARKETO_MA_LEAD_FIELD_REST_KEY})) {
+              $formatted_data[$field->{MARKETO_MA_LEAD_FIELD_REST_KEY}] = $value;
+            }
+          }
+        }
+        break;
+      case 'munchkin':
+      default:
+        // Replace marketo_id with value of MARKETO_REST_LEAD_FIELD_MUNCHKIN_KEY.
+        foreach ($raw_data as $id => $value) {
+          // Get the row corresponding to the marketo id.
+          $result = db_select(MARKETO_MA_SCHEMA_LEAD_FIELDS)
+            ->fields(MARKETO_MA_SCHEMA_LEAD_FIELDS)
+            ->condition(MARKETO_MA_LEAD_FIELD_ID, $id)
+            ->execute()
+            ->fetchAll();
+          // Cycle through the result row(s) and set the new munchkin field key.
+          foreach ($result as $field) {
+            if (isset($field->{MARKETO_MA_LEAD_FIELD_MUNCHKIN_KEY})) {
+              $formatted_data[$field->{MARKETO_MA_LEAD_FIELD_MUNCHKIN_KEY}] = $value;
+            }
+          }
+        }
+        break;
+    }
+    return $formatted_data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setEmailAddress($email) {
+    $formatted_data = $this->getFormattedData();
+    // Format the data based on tracking method.
+    switch ($this->getTrackingMethod()) {
+      case 'rest':
+        $formatted_data['email'] = $email;
+        break;
+      case 'munchkin':
+      default:
+        $formatted_data['Email'] = $email;
+        break;
+    }
+    $this->setFormattedData($formatted_data);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setFormattedData($formatted_data){
+    $this->formatted_data = $formatted_data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getEmailKey($tracking_method = null) {
+    $key = null;
+    // Format the data based on tracking method.
+    switch ($tracking_method) {
+      case 'rest':
+        $key = 'email';
+        break;
+      case 'munchkin':
+      default:
+        $key = 'Email';
+        break;
+    }
+
+    return $key;
+  }
+
+}

--- a/marketo_ma.module
+++ b/marketo_ma.module
@@ -16,8 +16,10 @@ define('MARKETO_MA_WEBFORM_OPTIONS', 'options');
 
 define('MARKETO_MA_SCHEMA_WEBFORM_COMPONENT', 'marketo_ma_webform_component');
 define('MARKETO_MA_WEBFORM_COMPONENT_KEY', 'marketo_ma_key');
-define('MARKETO_MA_LEAD_FIELD_ID', 'marketo_id');
 define('MARKETO_MA_WEBFORM_COMPONENT_NONE', 'none');
+define('MARKETO_MA_LEAD_FIELD_ID', 'marketo_id');
+define('MARKETO_MA_LEAD_FIELD_REST_KEY', 'restName');
+define('MARKETO_MA_LEAD_FIELD_MUNCHKIN_KEY', 'soapName');
 
 /**
  * Implements hook_menu().
@@ -302,18 +304,6 @@ function _marketo_ma_associate_lead_munchkin($lead) {
   if (_marketo_ma_munchkin_is_configured()) {
     $key = variable_get('marketo_ma_munchkin_api_private_key', NULL);
 
-    // Marketo MA uses REST field names by default and Munchkin uses SOAP names.
-    // Update field names to their SOAP equivalent and exclude fields which have
-    // no associated SOAP equivalent.
-    $fields = _marketo_ma_get_fields(TRUE); // get fields as defined in db.
-    $newLeadData = array();
-    foreach ($lead['data'] as $marketoKey => $marketoValue) {
-      if (array_key_exists($marketoKey, $fields)) {
-        $newLeadData[$fields[$marketoKey]['soapName']] = $marketoValue;
-      }
-    }
-    $lead['data'] = $newLeadData;
-
     if (variable_get('marketo_ma_logging', FALSE)) {
       watchdog('marketo', 'Associating lead !email [@method] <pre>@data</pre>', array(
         '!email' => $lead['email'],
@@ -397,8 +387,10 @@ function _marketo_ma_associate_lead_rest($lead) {
 
     try {
       $client = _marketo_ma_client();
+
+      // @todo: address usage of array('extendedResponse' => TRUE) option.
       $sync = $client->syncLead(array($lead['data']), NULL, $mkto_trk);
-//      $sync = $client->syncLead($lead['data'], $lead['email'], $mkto_trk, array('extendedResponse' => TRUE));
+
       if ($sync->success) {
         if (variable_get('marketo_ma_logging', FALSE)) {
           watchdog('marketo', 'Associating lead !email [rest] <pre>@data @result</pre>', array(
@@ -518,7 +510,7 @@ function _marketo_ma_get_fields($cache = FALSE, $update_cache = FALSE) {
 function _marketo_ma_save_lead_fields_database($fields) {
   foreach ($fields as $key => $value) {
     // TODO: field validation and error checking
-    $execute = db_merge('marketo_ma_lead_fields')
+    db_merge('marketo_ma_lead_fields')
       ->key(array('id' => $value['id']))
       ->fields(array(
         'displayName' => $value['displayName'],
@@ -600,7 +592,7 @@ function marketo_ma_get_lead_activity($key) {
 /**
  * Tests to see if Marketo MA has a valid configuration.
  * 
- * @staticvar bool $configured
+ * @static bool $configured
  * @return bool
  *   Returns TRUE if Munchkin settings are configured
  */
@@ -747,6 +739,8 @@ function _marketo_ma_visibility_pages() {
  */
 function _marketo_ma_visibility_roles($account) {
   static $role_match;
+
+  $enabled = NULL;
 
   // Cache visibility result if function is called more than once.
   if (!isset($role_match)) {

--- a/marketo_ma.module
+++ b/marketo_ma.module
@@ -16,6 +16,7 @@ define('MARKETO_MA_WEBFORM_OPTIONS', 'options');
 
 define('MARKETO_MA_SCHEMA_WEBFORM_COMPONENT', 'marketo_ma_webform_component');
 define('MARKETO_MA_WEBFORM_COMPONENT_KEY', 'marketo_ma_key');
+define('MARKETO_MA_LEAD_FIELD_ID', 'marketo_id');
 define('MARKETO_MA_WEBFORM_COMPONENT_NONE', 'none');
 
 /**
@@ -463,10 +464,10 @@ function _marketo_ma_get_field_options($labels = TRUE, $sort = TRUE) {
     // if no mapped fields return everything else filter down to only those selected.
     if (count($mapped_fields) == 0 || array_key_exists($value['id'], $mapped_fields)) {
       if ($labels) {
-        $options[$value['restName']] = $value['displayName'] . ' (' . $value['restName'] . ')';
+        $options[$value['id']] = $value['displayName'] . ' (' . $value['restName'] . ')';
       }
       else {
-        $options[$value['restName']] = $value['displayName'];
+        $options[$value['id']] = $value['displayName'];
       }
     }
   }

--- a/user/marketo_ma_user.module
+++ b/user/marketo_ma_user.module
@@ -134,8 +134,9 @@ function marketo_ma_user_user_login(&$edit, $account) {
   $triggers = variable_get('marketo_ma_user_triggers', array());
   if (array_key_exists('login', $triggers) && $triggers['login'] && isset($account->mail)) {
     $data = _marketo_ma_user_get_mapped_fields($account);
-    $data['email'] = $account->mail;
-    marketo_ma_add_lead($account->mail, $data);
+    $marketo_data = new MarketoMaData($data, variable_get('marketo_ma_tracking_method', MARKETO_MA_TRACKING_METHOD_DEFAULT));
+    $marketo_data->setEmailAddress($account->mail);
+    marketo_ma_add_lead($account->mail, $marketo_data);
   }
 }
 
@@ -146,8 +147,9 @@ function marketo_ma_user_user_insert(&$edit, $account, $category) {
   $triggers = variable_get('marketo_ma_user_triggers', array());
   if (array_key_exists('insert', $triggers) && $triggers['insert'] && isset($account->mail)) {
     $data = _marketo_ma_user_get_mapped_fields($account);
-    $data['email'] = $account->mail;
-    marketo_ma_add_lead($account->mail, $data);
+    $marketo_data = new MarketoMaData($data, variable_get('marketo_ma_tracking_method', MARKETO_MA_TRACKING_METHOD_DEFAULT));
+    $marketo_data->setEmailAddress($account->mail);
+    marketo_ma_add_lead($account->mail, $marketo_data);
   }
 }
 
@@ -161,8 +163,9 @@ function marketo_ma_user_user_update(&$edit, $account, $category) {
     // See https://api.drupal.org/comment/23088#comment-23088
     // When email changes, can we create a new lead then merge the two?
     $data = _marketo_ma_user_get_mapped_fields($account);
-    $data['email'] = $account->mail;
-    marketo_ma_add_lead($account->mail, $data);
+    $marketo_data = new MarketoMaData($data, variable_get('marketo_ma_tracking_method', MARKETO_MA_TRACKING_METHOD_DEFAULT));
+    $marketo_data->setEmailAddress($account->mail);
+    marketo_ma_add_lead($account->mail, $marketo_data);
   }
 }
 

--- a/webform/includes/marketo_ma_webform.webform_settings.inc
+++ b/webform/includes/marketo_ma_webform.webform_settings.inc
@@ -146,16 +146,19 @@ function _marketo_ma_webform_save_webform($form, &$form_state) {
     ->execute();
 
   if (isset($form_state['values']['components'])) {
-    foreach ($form_state['values']['components'] as $cid => $marketo) {
-      db_merge(MARKETO_MA_SCHEMA_WEBFORM_COMPONENT)
-        ->key(array(
-          'nid' => $nid,
-          'cid' => $cid,
-        ))
-        ->fields(array(
-          MARKETO_MA_WEBFORM_COMPONENT_KEY => $marketo,
-        ))
-        ->execute();
+    foreach ($form_state['values']['components'] as $cid => $marketo_id) {
+      // Ignore non numeric values.
+      if (is_numeric($marketo_id) || $marketo_id == MARKETO_MA_WEBFORM_COMPONENT_NONE) {
+        db_merge(MARKETO_MA_SCHEMA_WEBFORM_COMPONENT)
+          ->key(array(
+            'nid' => $nid,
+            'cid' => $cid,
+          ))
+          ->fields(array(
+            MARKETO_MA_LEAD_FIELD_ID => $marketo_id,
+          ))
+          ->execute();
+      }
     }
   }
 

--- a/webform/marketo_ma_webform.install
+++ b/webform/marketo_ma_webform.install
@@ -55,8 +55,8 @@ function marketo_ma_webform_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
-      MARKETO_MA_WEBFORM_COMPONENT_KEY => array(
-        'description' => 'The Marketo form field.',
+      MARKETO_MA_LEAD_FIELD_ID => array(
+        'description' => 'The Marketo form field id.',
         'type' => 'varchar',
         'length' => 128,
       ),
@@ -123,4 +123,18 @@ function marketo_ma_webform_update_7200(&$sandbox) {
   }
   if ($message == '') $message = t('No webform updates required');
   return $message;
+}
+
+/**
+ * Change Webform component mapping to marketo_id.
+ */
+function marketo_ma_webform_update_7201(&$sandbox) {
+  db_change_field(MARKETO_MA_SCHEMA_WEBFORM_COMPONENT, MARKETO_MA_WEBFORM_COMPONENT_KEY, MARKETO_MA_LEAD_FIELD_ID,
+    array(
+      'description' => 'The Marketo form field id.',
+      'type' => 'varchar',
+      'length' => 128,
+    )
+  );
+  return t('Updated Webform component mapping to use marketo field id `marketo_id`.');
 }

--- a/webform/marketo_ma_webform.module
+++ b/webform/marketo_ma_webform.module
@@ -104,7 +104,7 @@ function marketo_ma_webform_webform_submission_insert($node, $submission) {
     $data = array();
     $fieldmap = _marketo_ma_webform_get_mapped_fields($node->nid);
     foreach ($fieldmap as $cid => $key) {
-      if ($key != MARKETO_MA_WEBFORM_COMPONENT_NONE) {
+      if (!empty($key) && $key != MARKETO_MA_WEBFORM_COMPONENT_NONE) {
         // https://drupal.org/node/1609324#submission-structure
         if (isset($submission->data[$cid]['value'][0])) {
           $data[$key] = $submission->data[$cid]['value'][0];
@@ -153,7 +153,7 @@ function _marketo_ma_webform_get_mapped_fields($nid) {
     ->execute()
     ->fetchAll();
   foreach ($result as $field) {
-    $data[$field->cid] = $field->marketo_ma_key;
+    $data[$field->cid] = $field->marketo_id;
   }
   return $data;
 }
@@ -210,12 +210,11 @@ function _marketo_ma_webform_details($nid) {
 function marketo_ma_webform_list() {
   $webform_types = webform_variable_get('webform_node_types');
 
-  $nodes = array();
   if ($webform_types) {
     $components = db_select(MARKETO_MA_SCHEMA_WEBFORM_COMPONENT, 'mmwc');
     $components->addField('mmwc', 'nid');
-    $components->addExpression('count(' . MARKETO_MA_WEBFORM_COMPONENT_KEY . ')', 'components');
-    $components->condition('marketo_ma_key', 'none', '<>');
+    $components->addExpression('count(' . MARKETO_MA_LEAD_FIELD_ID . ')', 'components');
+    $components->condition('marketo_id', 'none', '<>');
     $components->groupBy('nid');
 
     $nodes = db_select('node', 'n');

--- a/webform/marketo_ma_webform.module
+++ b/webform/marketo_ma_webform.module
@@ -119,19 +119,22 @@ function marketo_ma_webform_webform_submission_insert($node, $submission) {
       }
     }
 
+    // Use the data helper to format data based on tracking method.
+    $marketo_data = new MarketoMaData($data, variable_get('marketo_ma_tracking_method', MARKETO_MA_TRACKING_METHOD_DEFAULT));
+
     /*
      * Check to see if an Email field has been provided. If not, we will try
-     * to use the current logged in user info
+     * to use the currently logged in user's info.
      */
-    if (!isset($data['email']) || $data['email'] == '') {
+    if (!$marketo_data->getEmailAddress()) {
       global $user;
       if (isset($user->mail)) {
-        $data['email'] = $user->mail;
+        $marketo_data->setEmailAddress($user->mail);
       }
     }
 
-    if (array_key_exists('email', $data)) {
-      marketo_ma_add_lead($data['email'], $data, FALSE, $webform->options);
+    if ($email = $marketo_data->getEmailAddress()) {
+      marketo_ma_add_lead($email, $marketo_data, FALSE, $webform->options);
     }
   }
 }


### PR DESCRIPTION
Hey @jyokum - I started on this for https://github.com/MarketoMA/marketo_ma/issues/15 but it's only WIP as I'm getting finishing here for this evening.

A few points to note:

* I only changed field name of `marketo_key` field in DB and added a hook for ease of testing. A hook for DB update is note required for dev release, so not sure if you want to include it. I think the key should be the same as that in the `marketo_ma_lead_fields` table also, but I didn't want to change that yet. Also the type was left as varchar though it should match that in `marketo_ma_lead_fields` also.

* I did not take care of the situation where tracking method can be changed. I believe in this PR we can just check for a NULL key and ignore any null field names when syncing with Marketo. i.e. - a `!empty($key)` was added in `marketo_ma_webform_webform_submission_insert`. We can do some kind of smarter fallback if tracking type is changed and the already mapped webform field has a null key for new tracking type in a separate PR.

* Most importantly, it is not currently working. We need some method to convert the marketo field ids in `$data` to the current tracking methods keys. I found that I took care of this in a separate kind of helper class to map the items, but I'm not a huge fan of this**. I'll have a think, but please let me know if you have any suggestions on how you would like to tackle this in marketo_ma. We also need to take care of this everywhere we use the `email` key for syncing with Marketo, as with Munchkin it is an `Email` key. 

** https://github.com/mccrodp/marketo_rest/blob/7.x-1.x/includes/marketo_rest.data.inc & used from this line down https://github.com/mccrodp/marketo_rest/blob/7.x-1.x/webform/marketo_rest_webform.module#L123

That's all I can think of for the moment.