### PR TITLE
REST SOAP field mapping updates

### DIFF
--- a/marketo_ma.module
+++ b/marketo_ma.module
@@ -85,7 +85,7 @@ function marketo_ma_add_lead($email, $data = array(), $merge = FALSE, $options =
   }
 
   if ($merge && array_key_exists($email, $marketo_ma_data)) {
-    $marketo_ma_data[$email]['data'] = array_merge($marketo_ma_data[$email]['data'], $data);
+    $marketo_ma_data[$email]['data'] += $data;
   }
   else {
     $marketo_ma_data[$email]['data'] = $data;
@@ -94,9 +94,9 @@ function marketo_ma_add_lead($email, $data = array(), $merge = FALSE, $options =
   $marketo_ma_data[$email]['options'] = $options;
 
   // Check to see if there is a default lead source we should apply.
-  $source = variable_get('marketo_ma_munchkin_lead_source');
-  if (!array_key_exists('LeadSource', $marketo_ma_data[$email]['data']) && $source !== '') {
-    $marketo_ma_data[$email]['data']['LeadSource'] = $source;
+  $source = variable_get('marketo_ma_munchkin_lead_source', '');
+  if ($source !== '') {
+    $marketo_ma_data[$email]['data']['leadSource'] = $source;
   }
 
   // If the user executing this method is anonymous or is actually the lead
@@ -269,6 +269,7 @@ function _marketo_ma_associate_lead($lead) {
   if (isset($lead['options']['tracking_method']) && $lead['options']['tracking_method'] != 'default') {
     $track = $lead['options']['tracking_method'];
   }
+  _marketo_ma_resolve_field_names($lead, $track);
   switch ($track) {
     case 'munchkin':
       _marketo_ma_associate_lead_munchkin($lead);
@@ -300,18 +301,6 @@ function _marketo_ma_associate_lead($lead) {
 function _marketo_ma_associate_lead_munchkin($lead) {
   if (_marketo_ma_munchkin_is_configured()) {
     $key = variable_get('marketo_ma_munchkin_api_private_key', NULL);
-
-    // Marketo MA uses REST field names by default and Munchkin uses SOAP names.
-    // Update field names to their SOAP equivalent and exclude fields which have
-    // no associated SOAP equivalent.
-    $fields = _marketo_ma_get_fields(TRUE); // get fields as defined in db.
-    $newLeadData = array();
-    foreach ($lead['data'] as $marketoKey => $marketoValue) {
-      if (array_key_exists($marketoKey, $fields)) {
-        $newLeadData[$fields[$marketoKey]['soapName']] = $marketoValue;
-      }
-    }
-    $lead['data'] = $newLeadData;
 
     if (variable_get('marketo_ma_logging', FALSE)) {
       watchdog('marketo', 'Associating lead !email [@method] <pre>@data</pre>', array(
@@ -463,10 +452,10 @@ function _marketo_ma_get_field_options($labels = TRUE, $sort = TRUE) {
     // if no mapped fields return everything else filter down to only those selected.
     if (count($mapped_fields) == 0 || array_key_exists($value['id'], $mapped_fields)) {
       if ($labels) {
-        $options[$value['restName']] = $value['displayName'] . ' (' . $value['restName'] . ')';
+        $options[$value['id']] = $value['displayName'] . ' (' . $value['restName'] . ')';
       }
       else {
-        $options[$value['restName']] = $value['displayName'];
+        $options[$value['id']] = $value['displayName'];
       }
     }
   }
@@ -538,13 +527,62 @@ function _marketo_ma_save_lead_fields_database($fields) {
  * @return array
  *   Associative array of lead fields keyed by their REST API name
  */
-function _marketo_ma_get_lead_fields_database() {
+function _marketo_ma_get_lead_fields_database($key = 'id') {
   $result = db_select('marketo_ma_lead_fields', 'f')
     ->fields('f')
     ->orderBy('displayName')
     ->execute()
-    ->fetchAllAssoc('restName', PDO::FETCH_ASSOC);
+    ->fetchAllAssoc($key, PDO::FETCH_ASSOC);
   return $result;
+}
+
+/*
+ * Ensures fields are mapped to the proper key based on tracking method.
+ *
+ * @param array $lead
+ *   Lead
+ * @param string $tracking_method
+ *   Marketo tracking method
+ */
+function _marketo_ma_resolve_field_names(&$lead, $tracking_method) {
+  if ($tracking_method == 'rest' || $tracking_method == 'rest_async') {
+    $key = 'restName';
+  }
+  else {
+    $key = 'soapName';
+  }
+  $fields = _marketo_ma_get_lead_fields_database();
+  $lead_data = array();
+  // Sort data so text keys are first. Text keys were likely set manually rather
+  // than by mapped fields and we'll let them be overwritten by mappings.
+  ksort($lead['data']);
+  foreach ($lead['data'] as $label => $value) {
+    if (is_numeric($label) && array_key_exists($label, $fields)) {
+      // Change the numeric ID to the field key
+      $lead_data[$fields[$label][$key]] = $value;
+    }
+    else if (is_null($label) || trim($label) == '') {
+      // Shouldn't happen but ignore anything with a blank key
+      watchdog('marketo', 'A blank lead key was found, data will not be submitted. !label = !value ', array('!label' => $label, '!value' => $value), WATCHDOG_WARNING);
+    }
+    else {
+      // Check the DB to see if we can match on other fields
+      $result = db_select('marketo_ma_lead_fields', 'f')
+        ->fields('f')
+        ->condition(db_or()->condition('restName', $label)->condition('soapName', $label))
+        ->execute()
+        ->fetchAll();
+      if ($result) {
+        // TODO: Handle case where multiple results are returned
+        $lead_data[$result[0]->{$key}] = $value;
+      }
+      else {
+        // Ignore unknown key. It wasn't numeric, blank, or found in restName/soapName.
+        watchdog('marketo', 'An unknown lead key was found, data will not be submitted. !label = !value ', array('!label' => $label, '!value' => $value), WATCHDOG_WARNING);
+      }
+    }
+  }
+  $lead['data'] = $lead_data;
 }
 
 /**

--- a/tests/behat/behat.yml.dist
+++ b/tests/behat/behat.yml.dist
@@ -80,7 +80,7 @@ default:
 
               marketo_default_lead_fields:
                 1:
-                  id: 1
+                  id: 48
                   displayName: First Name
                   dataType: string
                   length: 255
@@ -90,7 +90,7 @@ default:
                   soapReadOnly: 0
                   enabled: 0
                 2:
-                  id: 2
+                  id: 50
                   displayName: Last Name
                   dataType: string
                   length: 255
@@ -100,7 +100,7 @@ default:
                   soapReadOnly: 0
                   enabled: 0
                 3:
-                  id: 3
+                  id: 51
                   displayName: Email Address
                   dataType: string
                   length: 255

--- a/tests/behat/features/admin/marketo_ma_user.feature
+++ b/tests/behat/features/admin/marketo_ma_user.feature
@@ -31,8 +31,8 @@ Feature: Marketo MA User features
     And I select "lastName" from "field_company123 (field_company123)"
     And I press "Save configuration"
     Then I should see "The configuration options have been saved."
-    And the "[account:name] (name)" field should contain "lastName"
-    And the "field_company123 (field_company123)" field should contain "lastName"
+    And the "[account:name] (name)" field should contain "50"
+    And the "field_company123 (field_company123)" field should contain "50"
 
     When I go to "/user"
     And I click "Edit"

--- a/user/marketo_ma_user.module
+++ b/user/marketo_ma_user.module
@@ -116,9 +116,8 @@ function marketo_ma_user_form_marketo_ma_admin_settings_form_alter(&$form, &$for
     );
     if (array_key_exists($key, $fieldmap)) {
       if (!array_key_exists($fieldmap[$key], $options)) {
-        $form['marketo_ma_tabs']['marketo_ma_user']['marketo_ma_user_fieldmap'][$key]['#options'] = array_merge(
-          array($fieldmap[$key] => "Undefined Field ($fieldmap[$key])"), $options
-        );
+        $form['marketo_ma_tabs']['marketo_ma_user']['marketo_ma_user_fieldmap'][$key]['#options'] +=
+          array($fieldmap[$key] => "Undefined Field ($fieldmap[$key])");
         drupal_set_message(t('An undefined field [@field] is currently used in User Integration settings and should be updated.', array('@field' => $fieldmap[$key])), 'warning');
       }
 

--- a/user/marketo_ma_user.module
+++ b/user/marketo_ma_user.module
@@ -103,9 +103,8 @@ function marketo_ma_user_form_marketo_ma_admin_settings_form_alter(&$form, &$for
   $user_fields = _marketo_ma_user_get_user_fields();
   $user_fields += field_info_instances('user', 'user');
   $fieldmap = variable_get('marketo_ma_user_fieldmap', array());
-  $default_options = array(MARKETO_MA_WEBFORM_COMPONENT_NONE => '- None -');
-  $marketo_options = _marketo_ma_get_field_options();
-  $options = array_merge($default_options, $marketo_options);
+  $options = array(MARKETO_MA_WEBFORM_COMPONENT_NONE => '- None -');
+  $options += _marketo_ma_get_field_options();
 
   foreach ($user_fields as $key => $value) {
     $form['marketo_ma_tabs']['marketo_ma_user']['marketo_ma_user_fieldmap'][$key] = array(
@@ -113,6 +112,7 @@ function marketo_ma_user_form_marketo_ma_admin_settings_form_alter(&$form, &$for
       '#title_display' => 'invisible',
       '#type' => 'select',
       '#options' => $options,
+      '#default_value' => MARKETO_MA_WEBFORM_COMPONENT_NONE,
     );
     if (array_key_exists($key, $fieldmap)) {
       if (!array_key_exists($fieldmap[$key], $options)) {

--- a/webform/includes/marketo_ma_webform.webform_settings.inc
+++ b/webform/includes/marketo_ma_webform.webform_settings.inc
@@ -72,9 +72,8 @@ function marketo_ma_webform_settings_form($form, &$form_state, $node) {
     '#theme' => 'marketo_ma_webform_fieldmap',
   );
 
-  $default_options = array(MARKETO_MA_WEBFORM_COMPONENT_NONE => '- None -');
-  $marketo_options = _marketo_ma_get_field_options();
-  $options = array_merge($default_options, $marketo_options);
+  $options = array(MARKETO_MA_WEBFORM_COMPONENT_NONE => '- None -');
+  $options += _marketo_ma_get_field_options();
   $fieldmap = _marketo_ma_webform_get_mapped_fields($node->nid);
   foreach ($node->webform['components'] as $cid => $component) {
     $form['components'][$cid] = array(

--- a/webform/includes/marketo_ma_webform.webform_settings.inc
+++ b/webform/includes/marketo_ma_webform.webform_settings.inc
@@ -85,8 +85,8 @@ function marketo_ma_webform_settings_form($form, &$form_state, $node) {
     );
     if (array_key_exists($cid, $fieldmap)) {
       if (!array_key_exists($fieldmap[$cid], $options)) {
-        $form['components'][$cid]['#options'] = array_merge(
-          array($fieldmap[$cid] => "Undefined Field ($fieldmap[$cid])"), $options
+        $form['components'][$cid]['#options'] += array(
+          $fieldmap[$cid] => "Undefined Field ($fieldmap[$cid])"
         );
         drupal_set_message(t('An undefined field [@field] is currently used and should be updated.', array('@field' => $fieldmap[$cid])), 'warning');
       }


### PR DESCRIPTION
Changes webform and user field mappings to use ID rather than restName as key. Fields are remapped to the appropriate key prior to sending to Marketo based on the tracking method.

To address #15 and an alternate approach to #21 