### PR TITLE
#2854259: Support triggerCampaignUsingPost REST API endpoint

### DIFF
--- a/src/Service/MarketoMaApiClient.php
+++ b/src/Service/MarketoMaApiClient.php
@@ -163,4 +163,13 @@ class MarketoMaApiClient implements MarketoMaApiClientInterface {
     return $this->getClient()->deleteLead($leads)->getResult();
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function requestCampaign($campaignId, $leads, $tokens = array(), $args = array()) {
+    $result = $this->getClient()->requestCampaign($campaignId, $leads, $tokens, $args)->getResult();
+
+    return $result;
+  }
+
 }

--- a/src/Service/MarketoMaApiClient.php
+++ b/src/Service/MarketoMaApiClient.php
@@ -166,7 +166,7 @@ class MarketoMaApiClient implements MarketoMaApiClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function requestCampaign($campaignId, $leads, $tokens = array(), $args = array()) {
+  public function requestCampaign($campaignId, $leads, $tokens = [], $args = []) {
     $result = $this->getClient()->requestCampaign($campaignId, $leads, $tokens, $args)->getResult();
 
     return $result;

--- a/src/Service/MarketoMaApiClientInterface.php
+++ b/src/Service/MarketoMaApiClientInterface.php
@@ -113,6 +113,6 @@ interface MarketoMaApiClientInterface {
    *
    * @return mixed
    */
-  public function requestCampaign($campaignId, $leads, $tokens = array(), $args = array());
+  public function requestCampaign($campaignId, $leads, $tokens = [], $args = []);
 
 }

--- a/src/Service/MarketoMaApiClientInterface.php
+++ b/src/Service/MarketoMaApiClientInterface.php
@@ -100,4 +100,19 @@ interface MarketoMaApiClientInterface {
    */
   public function deleteLead($leads, $args = array());
 
+  /**
+   * Trigger campaign flows by requesting a campaign.
+   *
+   * @param int $campaignId
+   *   The id of the campaign to be triggered.
+   * @param int|array $leads
+   *   Either a single lead ID or an array of lead IDs.
+   * @param array $tokens
+   *   An array of token values to replace during campaign execution.
+   * @param array $args
+   *
+   * @return mixed
+   */
+  public function requestCampaign($campaignId, $leads, $tokens = array(), $args = array());
+
 }


### PR DESCRIPTION
Add support within the API Client for the [`triggerCampaignUsingPost`](http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Campaigns/triggerCampaignUsingPOST) REST API endpoint. 

Related D.O issue: [#2854259: Support triggerCampaignUsingPost REST API endpoint](https://www.drupal.org/node/2854259)