### PR TITLE
#2854264: Add a post-sync hook for lead sync operations.

### DIFF
--- a/marketo_ma.api.php
+++ b/marketo_ma.api.php
@@ -30,6 +30,28 @@ function hook_marketo_ma_lead_alter(&$data) {
 }
 
 /**
+ * This hook is executed after a lead sync operation by the API client.
+ *
+ * @param Drupal\marketo_ma\Service\MarketoMaApiClient $client
+ * @param array|NULL $result
+ * @param Drupal\marketo_ma\Lead $lead
+ * @param $key
+ * @param $options
+ *
+ * @see \Drupal\marketo_ma\Service\MarketoMaApiClient::syncLead()
+ */
+function hook_marketo_ma_lead_post_sync(Drupal\marketo_ma\Service\MarketoMaApiClient $client, $result, Drupal\marketo_ma\Lead $lead, $key, $options) {
+  // Identify the lead id that was synced.
+  if (isset($result[0]) && isset($result[0]['id'])) {
+    $lead_id = $result[0]['id'];
+  }
+  else {
+    // Abort if there was no successful lead ID provided.
+    return;
+  }
+}
+
+/**
  * This hook is executed for a specific FIELDNAME when a lead is added to the
  * queue for submission.
  *

--- a/src/Service/MarketoMaApiClient.php
+++ b/src/Service/MarketoMaApiClient.php
@@ -4,6 +4,7 @@ namespace Drupal\marketo_ma\Service;
 
 use CSD\Marketo\Client;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\encryption\EncryptionTrait;
 use Drupal\marketo_ma\Lead;
 use Psr\Log\LoggerInterface;
@@ -153,6 +154,17 @@ class MarketoMaApiClient implements MarketoMaApiClientInterface {
   public function syncLead(Lead $lead, $key = 'email', $options = []) {
     // Add the create/update leads call to do the association.
     $result = $this->getClient()->createOrUpdateLeads([$lead->data()], $key, $options)->getResult();
+
+    /** @var ModuleHandlerInterface $module_handler */
+    $module_handler = \Drupal::service('module_handler');
+    $module_handler->invokeAll('marketo_ma_lead_post_sync', array(
+      $this,
+      $result,
+      $lead,
+      $key,
+      $options,
+    ));
+
     return $result;
   }
 


### PR DESCRIPTION
Without this hook, there is no straight-forward place to hook into the
lead sync process with access to the completed sync ID result.

Related D.O issue: [#2854264: Add a post-sync hook for lead synchronization](https://www.drupal.org/node/2854264)