### PR TITLE
#2861365: Add a client callback for the associateLead API endpoint.

### DIFF
--- a/src/Service/MarketoMaApiClient.php
+++ b/src/Service/MarketoMaApiClient.php
@@ -167,7 +167,7 @@ class MarketoMaApiClient implements MarketoMaApiClientInterface {
    * {@inheritdoc}
    */
   public function associateLead($leadId, $cookie, $args = []) {
-    $result = $this->getClient()->associateLead($leadId, $cookie), $args;
+    $result = $this->getClient()->associateLead($leadId, $cookie);
 
     return $result;
   }

--- a/src/Service/MarketoMaApiClient.php
+++ b/src/Service/MarketoMaApiClient.php
@@ -166,7 +166,7 @@ class MarketoMaApiClient implements MarketoMaApiClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function associateLead($leadId, $cookie, $args = array()) {
+  public function associateLead($leadId, $cookie, $args = []) {
     $result = $this->getClient()->associateLead($leadId, $cookie), $args;
 
     return $result;

--- a/src/Service/MarketoMaApiClient.php
+++ b/src/Service/MarketoMaApiClient.php
@@ -163,4 +163,13 @@ class MarketoMaApiClient implements MarketoMaApiClientInterface {
     return $this->getClient()->deleteLead($leads)->getResult();
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function associateLead($leadId, $cookie, $args = array()) {
+    $result = $this->getClient()->associateLead($leadId, $cookie), $args;
+
+    return $result;
+  }
+
 }

--- a/src/Service/MarketoMaApiClientInterface.php
+++ b/src/Service/MarketoMaApiClientInterface.php
@@ -100,4 +100,17 @@ interface MarketoMaApiClientInterface {
    */
   public function deleteLead($leads, $args = array());
 
+  /**
+   * Associate a known lead with activity recorded by a cookie.
+   *
+   * @param $leadId
+   *   The id of the lead whose activity should be associated with the cookie.
+   * @param $cookie
+   *   The browser cookie value to associate with the lead.
+   * @param array $args
+   *
+   * @return mixed
+   */
+  public function associateLead($leadId, $cookie, $args = array());
+
 }

--- a/src/Service/MarketoMaApiClientInterface.php
+++ b/src/Service/MarketoMaApiClientInterface.php
@@ -111,6 +111,6 @@ interface MarketoMaApiClientInterface {
    *
    * @return mixed
    */
-  public function associateLead($leadId, $cookie, $args = array());
+  public function associateLead($leadId, $cookie, $args = []);
 
 }


### PR DESCRIPTION
Add a pass-through function to the API client to support the
associateLead command provided by the Marketo REST Client.

This work is related to [Drupal Issue #2861365](https://www.drupal.org/node/2861365).