### PR TITLE
#2862238: Add functionality to sync a custom object.

### DIFF
--- a/marketo_ma.api.php
+++ b/marketo_ma.api.php
@@ -30,6 +30,20 @@ function hook_marketo_ma_lead_alter(&$data) {
 }
 
 /**
+ * This hook is executed when a custom object is prepared for submission.
+ *
+ * @param array $records
+ *   An associative array containing mapped custom object data keyed by
+ *   the target marketo field ID.
+ */
+function hook_marketo_ma_custom_object_alter(&$records) {
+  // Identify the site name as the source for each record.
+  foreach ($records as $record) {
+    $record['lead_source'] = 'site name';
+  }
+}
+
+/**
  * This hook is executed for a specific FIELDNAME when a lead is added to the
  * queue for submission.
  *

--- a/src/Service/MarketoMaApiClient.php
+++ b/src/Service/MarketoMaApiClient.php
@@ -4,6 +4,7 @@ namespace Drupal\marketo_ma\Service;
 
 use CSD\Marketo\Client;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\encryption\EncryptionTrait;
 use Drupal\marketo_ma\Lead;
 use Psr\Log\LoggerInterface;
@@ -161,6 +162,22 @@ class MarketoMaApiClient implements MarketoMaApiClientInterface {
    */
   public function deleteLead($leads, $args = array()) {
     return $this->getClient()->deleteLead($leads)->getResult();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function syncCustomObject($objectName, $action, $records, $dedupeBy = NULL, $options = []) {
+    /** @var ModuleHandlerInterface $module_handler */
+    $module_handler = \Drupal::service('module_handler');
+
+    // Allow custom object data to be altered before syncing it.
+    $module_handler->alter('marketo_ma_custom_object', $records, $objectName);
+
+    $result = $this->getClient()
+      ->createOrUpdateCustomObjects($objectName, $action, $records, $dedupeBy);
+
+    return $result;
   }
 
 }

--- a/src/Service/MarketoMaApiClientInterface.php
+++ b/src/Service/MarketoMaApiClientInterface.php
@@ -100,4 +100,20 @@ interface MarketoMaApiClientInterface {
    */
   public function deleteLead($leads, $args = array());
 
+  /**
+   * Inserts or updates a custom object.
+   *
+   * @param string $objectName
+   *   The name of the custom object according to Marketo.
+   * @param array $input
+   *   An array of values keyed by the field name to populate the object with.
+   * @param string $dedupeBy
+   *   (optional) An attribute to use to remove duplicates.
+   * @param array $options
+   *   Array of additional options to configure lead syncing
+   *
+   * @return array mixed
+   */
+  public function syncCustomObject($objectName, $action, $input, $dedupeBy = NULL, $options = []);
+
 }


### PR DESCRIPTION
Add support to create objects through the [custom object REST API](http://developers.marketo.com/rest-api/lead-database/custom-objects/#create_and_update).

Note, this is dependent on related functionality added to the underlying
marketo api project in [this PR](https://github.com/marketo-api/marketo-rest-client/pull/18).

This work is related to [issue #2862238](https://www.drupal.org/node/2862238) on Drupal.org.