### PR TITLE
Introduce list functionality

### DIFF
--- a/src/Service/MarketoMaApiClient.php
+++ b/src/Service/MarketoMaApiClient.php
@@ -174,7 +174,8 @@ class MarketoMaApiClient implements MarketoMaApiClientInterface {
    */
   public function addLeadsToList($listId, array $leads, array $options = []) {
     $leads_raw = $this->getLeadsIds($leads);
-    return $this->getClient()->addLeadsToList($listId, $leads_raw, $options)->getResult();
+    $result = $this->getClient()->addLeadsToList($listId, $leads_raw, $options)->getResult();
+    return $result;
   }
 
   /**

--- a/src/Service/MarketoMaApiClient.php
+++ b/src/Service/MarketoMaApiClient.php
@@ -4,6 +4,7 @@ namespace Drupal\marketo_ma\Service;
 
 use CSD\Marketo\Client;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Driver\Exception\Exception;
 use Drupal\encryption\EncryptionTrait;
 use Drupal\marketo_ma\Lead;
 use Psr\Log\LoggerInterface;
@@ -166,6 +167,52 @@ class MarketoMaApiClient implements MarketoMaApiClientInterface {
    */
   public function deleteLead($leads, $args = []) {
     return $this->getClient()->deleteLead($leads)->getResult();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addLeadsToList($listId, array $leads, array $options = []) {
+    $leads_raw = $this->getLeadsIds($leads);
+    kint($leads_raw);
+    return $this->getClient()->addLeadsToList($listId, $leads_raw, $options)->getResult();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addLeadToListByEmail($listId, $email, array $options = []) {
+    $this->syncLead(new Lead(['email' => $email]));
+    $this->addLeadsToList($listId, [$this->getLeadByEmail($email)], $options);
+  }
+
+  /**
+   * Helper method to transform a list of Leads to a coma separated string.
+   *
+   * @param array $leads
+   *   An array containing \Drupal\marketo_ma\Lead objects.
+   *
+   * @throws \Exception
+   *   In case the given array contains an element which is not a
+   *   \Drupal\marketo_ma\Lead object.
+   *
+   * @return string
+   *   A coma separated list of ids of the given Lead objects.
+   */
+  protected function getLeadsIds(array $leads) {
+    $leads_raw = '';
+
+    for ($i = 0; $i < count($leads); $i++) {
+      if (!is_a($leads[$i], 'Drupal\marketo_ma\Lead')) {
+        throw new \Exception('Only lead objects can be passed to the MarketoMaApiClient::addLeadsToList() method.');
+      }
+      $leads_raw .= $leads[$i]->id();
+      if ($i < count($leads) - 1) {
+        $leads_raw .= ',';
+      }
+    }
+
+    return $leads_raw;
   }
 
 }

--- a/src/Service/MarketoMaApiClient.php
+++ b/src/Service/MarketoMaApiClient.php
@@ -174,7 +174,6 @@ class MarketoMaApiClient implements MarketoMaApiClientInterface {
    */
   public function addLeadsToList($listId, array $leads, array $options = []) {
     $leads_raw = $this->getLeadsIds($leads);
-    kint($leads_raw);
     return $this->getClient()->addLeadsToList($listId, $leads_raw, $options)->getResult();
   }
 
@@ -201,8 +200,9 @@ class MarketoMaApiClient implements MarketoMaApiClientInterface {
    */
   protected function getLeadsIds(array $leads) {
     $leads_raw = '';
+    $total_leads = count($leads);
 
-    for ($i = 0; $i < count($leads); $i++) {
+    for ($i = 0; $i < $total_leads; $i++) {
       if (!is_a($leads[$i], 'Drupal\marketo_ma\Lead')) {
         throw new \Exception('Only lead objects can be passed to the MarketoMaApiClient::addLeadsToList() method.');
       }

--- a/src/Service/MarketoMaApiClientInterface.php
+++ b/src/Service/MarketoMaApiClientInterface.php
@@ -99,4 +99,40 @@ interface MarketoMaApiClientInterface {
    */
   public function deleteLead($leads, $args = []);
 
+  /**
+   * Adds an e-mail address to a given list.
+   *
+   * @param int $listId
+   *   The ID of the target list. The List Id can be obtained from the URL of
+   *   he list in the UI, where the URL will resemble
+   *   https://app-***.marketo.com/#ST1001A1. In this URL, the id is 1001, it
+   *   will always be between the first set of letters in the URL and the
+   *   second set of letters.
+   * @param string $email
+   *   The email address of the user that needs to be added to the list.
+   * @param array $options
+   *   Array of additional options to configure lead syncing.
+   *
+   * @return array|null
+   *   An array of response messages (errors) or NULL if the transaction was
+   *   successful.
+   */
+  public function addLeadToListByEmail($listId, $email, array $options = []);
+
+  /**
+   * Adds a given set of leads to a target static list.
+   *
+   * @param string $listId
+   *   The ID of the target list.
+   * @param array $leads
+   *   An array of \Drupal\marketo_ma\Lead objects.
+   * @param array $options
+   *   Array of additional options to configure lead syncing.
+   *
+   * @return array|null
+   *   An array of response messages (errors) or NULL if the transaction was
+   *   successful.
+   */
+  public function addLeadsToList($listId, array $leads, array $options = []);
+
 }

--- a/src/Service/MarketoMaService.php
+++ b/src/Service/MarketoMaService.php
@@ -11,6 +11,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\marketo_ma\FieldDefinitionSet;
+use Drupal\marketo_ma\Lead;
 use Drupal\user\PrivateTempStoreFactory;
 
 /**
@@ -300,6 +301,27 @@ class MarketoMaService implements MarketoMaServiceInterface {
     return $this;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function addLeadToList(Lead $lead, $listId) {
+    if ($this->trackingMethod() === MarketoMaServiceInterface::TRACKING_METHOD_API) {
+      $this->updateLeadResult = $this->api_client->addLeadsToList($listId, [$lead]);
+    }
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addLeadToListByEmail($email, $listId) {
+    if ($this->trackingMethod() === MarketoMaServiceInterface::TRACKING_METHOD_API) {
+      $this->updateLeadResult = $this->api_client->addLeadToListByEmail($listId, $email);
+    }
+
+    return $this;
+  }
   /**
    * {@inheritdoc}
    */

--- a/src/Service/MarketoMaServiceInterface.php
+++ b/src/Service/MarketoMaServiceInterface.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Drupal\marketo_ma\Service;
+use Drupal\marketo_ma\Lead;
 
 /**
  * Service interface for the `marketo_ma` worker service.
@@ -56,6 +57,29 @@ interface MarketoMaServiceInterface {
    */
   public function trackingMethod();
 
+  /**
+   * Adds a given lead to a given list.
+   *
+   * @param \Drupal\marketo_ma\Lead $lead
+   *   The Lead object.
+   * @param int $listId
+   *   The ID of the list in Marketo.
+   *
+   * @return $this
+   */
+  public function addLeadToList(Lead $lead, $listId);
+
+  /**
+   * Adds a given e-mail address to a list.
+   *
+   * @param string $email
+   *   The e-mail address of the lead.
+   * @param int $listId
+   *   The ID of the list in Marketo.
+   *
+   * @return $this
+   */
+  public function addLeadToListByEmail($email, $listId);
   /**
    * Sets temporary user data for this session.
    *

--- a/tests/src/Kernel/MarketoMaApiClientTest.php
+++ b/tests/src/Kernel/MarketoMaApiClientTest.php
@@ -104,6 +104,39 @@ class MarketoMaApiClientTest extends MarketoMaKernelTestBase {
   }
 
   /**
+   * Tests the adding of a lead to a list.
+   */
+  public function testAddLeadsToList() {
+    // Create a new lead.
+    $create_result = $this->_sync_lead();
+
+    // Get the newly synced lead.
+    $lead = $this->api_client->getLeadByEmail($this->test_lead_email);
+
+    // Add the lead to a list.
+    $this->api_client->addLeadsToList('1234', [$lead]);
+
+    // @todo: Add test for validating if the user was actually added.
+    // Clean up and delete the lead.
+    $this->api_client->deleteLead($create_result[0]['id']);
+  }
+
+  /**
+   * Tests the addinf of a lead to a list by a given email address.
+   */
+  public function testAddLeadToListByEmail() {
+    // Add an e-mail address to a list.
+    $this->api_client->addLeadToListByEmail('1234', $this->test_lead_email);
+
+    // Retrieve the created lead from the step above.
+    $lead = $this->api_client->getLeadByEmail($this->test_lead_email);
+
+    // @todo: Add test for validating if the user was actually added.
+    // Clean up and delete the lead.
+    $this->api_client->deleteLead($lead->id());
+  }
+
+  /**
    * @return array the syncLead result.
    */
   private function _sync_lead() {


### PR DESCRIPTION
I'm currently working on a module called `marketo_subscribe` as we needed functionality for users to be able to subscribe to a list in Marketo with only their e-mail address (no body field).

As the functionality for Lists in Marketo was missing in this module, I created two new public methods to the API Client:

- addLeadsToList() => Adds a given array of Lead objects to a list using the `addLeadsToList()` method on the base client
- addLeadToListByEmail() => Creates a new lead for the given e-mail address and then calls addLeadsToList().

I've also added unit tests for both the functions.