### PR TITLE
"By default, all fields below will be available for mapping to Webform and User Profile fields"

### DIFF
--- a/src/FieldDefinitionSet.php
+++ b/src/FieldDefinitionSet.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\marketo_ma;
 
+use Drupal\Core\Database\Database;
+
 /**
  *
  */
@@ -9,6 +11,7 @@ class FieldDefinitionSet {
 
   private $fieldset = [];
   private $readonly = [];
+  private $writeable = [];
 
   /**
    *
@@ -21,7 +24,7 @@ class FieldDefinitionSet {
    *
    */
   private function load() {
-    $this->fieldset = db_select('marketo_ma_lead_fields', 'f')
+    $this->fieldset = Database::getConnection()->select('marketo_ma_lead_fields', 'f')
       ->fields('f')
       ->orderBy('displayName')
       ->execute()
@@ -30,6 +33,9 @@ class FieldDefinitionSet {
       if ($field_value['restReadOnly'] || $field_value['soapReadOnly']) {
         $this->readonly[] = $field_value['id'];
       }
+      else {
+        $this->writeable[$field_key] = $field_value;
+      }
     }
   }
 
@@ -37,8 +43,8 @@ class FieldDefinitionSet {
    *
    */
   public function add($field) {
-    $execute = db_merge('marketo_ma_lead_fields')
-      ->key(['id' => $field['id']])
+    Database::getConnection()->merge('marketo_ma_lead_fields')
+      ->key('id', $field['id'])
       ->fields([
         'displayName' => $field['displayName'],
         'dataType' => $field['dataType'],
@@ -79,6 +85,10 @@ class FieldDefinitionSet {
    */
   public function getReadOnly() {
     return $this->readonly;
+  }
+
+  public function getWriteable() {
+    return $this->writeable;
   }
 
 }

--- a/src/Service/MarketoMaService.php
+++ b/src/Service/MarketoMaService.php
@@ -283,11 +283,11 @@ class MarketoMaService implements MarketoMaServiceInterface {
       // Do we need to batch the lead update?
       if (!$this->config()->get('rest.batch_requests')) {
         // Just sync the lead now.
-        $this->updateLeadResult = $this->api_client->syncLead($lead);
+        $this->updateLeadResult = $this->apiClient->syncLead($lead);
       }
       else {
         // Queue up the lead sync.
-        $this->queue_factory->get('marketo_ma_lead')->createItem($lead);
+        $this->queueFactory->get('marketo_ma_lead')->createItem($lead);
       }
 
       $this->resetUserData();

--- a/src/Service/MarketoMaServiceInterface.php
+++ b/src/Service/MarketoMaServiceInterface.php
@@ -129,7 +129,7 @@ interface MarketoMaServiceInterface {
    * Gets fields that are read-only in Marketo.
    *
    * @return array
-   *   All fields available for mapping keyed by marketo field ID.
+   *   A list of readonly marketo field IDs.
    */
   public function getReadOnly();
 
@@ -140,6 +140,15 @@ interface MarketoMaServiceInterface {
    *   All fields available for mapping keyed by marketo field ID.
    */
   public function getEnabledFields();
+
+  /**
+   * Gets available fields.
+   *
+   * @return \Drupal\marketo_ma\MarketoFieldDefinition[]
+   *   All fields available for mapping keyed by marketo field ID. If no
+   *   fields are enabled, all non-readonly fields are returned.
+   */
+  public function getAvailableFields();
 
   /**
    * Determines if the API client is configured and available.


### PR DESCRIPTION
That's what the help says but that's not what happens. Let's make it so. Also, I fixed some problems with https://www.drupal.org/docs/develop/standards/object-oriented-code#naming 'Methods and class properties should use lowerCamel naming".

I will have more PRs coming, I am adding forms2 support.